### PR TITLE
Add CC.LA to Information Gathering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The [Cybersecurity Bootcamp](https://www.academy.evolvesecurity.com/cybersecurit
 - 🧪 **[Dnsrecon](https://github.com/darkoperator/dnsrecon)** – Perform DNS enumeration and zone transfers.
 - 📜 **[Fierce](https://github.com/mschwager/fierce)** – DNS reconnaissance and attack tool.
 - 📄 **[WHOIS](https://www.whois.com/)** – Domain registration and ownership lookup.
+- 🔎 **[CC.LA](https://cc.la)** – Free WHOIS/RDAP lookup, DNS records, name server history, IP WHOIS, SSL certificate search, and network diagnostics.
 - 📬 **[EmailHarvester](https://github.com/maldevel/EmailHarvester)** – Email enumeration and gathering.
 - 🕸️ **[Shodan](https://www.shodan.io/)** – Search engine for internet-connected devices.
 - 🔥 **[Censys](https://censys.io/)** – Search engine for hosts and networks on the internet.


### PR DESCRIPTION
Adds [CC.LA](https://cc.la) to the **Information Gathering** section, right after the WHOIS entry.

CC.LA is a free domain research toolkit:
- WHOIS / RDAP lookup
- DNS records & name server history
- IP WHOIS
- SSL certificate search
- Network diagnostics (ping/traceroute/MTR)

No sign-up required. Entry format (emoji + bold link + dash description) matches the list.